### PR TITLE
Don't raise on empty Delux configurations

### DIFF
--- a/lib/delux.ex
+++ b/lib/delux.ex
@@ -12,6 +12,9 @@ defmodule Delux do
   @default_priorities [:status, :notification, :user_feedback]
 
   @default_indicator :default
+  @default_indicator_config %{default: %{}}
+
+  @default_led_path "/sys/class/leds"
 
   @typedoc """
   Priority of an indicator program
@@ -168,8 +171,8 @@ defmodule Delux do
   @impl GenServer
   def init(options) do
     priorities = options[:priorities] || @default_priorities
-    indicator_configs = options[:indicators]
-    led_path = options[:led_path] || "/sys/class/leds"
+    indicator_configs = options[:indicators] || @default_indicator_config
+    led_path = options[:led_path] || @default_led_path
 
     off = Effects.off()
     all_off = for {name, _config} <- indicator_configs, do: {name, off}

--- a/test/delux_test.exs
+++ b/test/delux_test.exs
@@ -3,6 +3,13 @@ defmodule DeluxTest do
 
   alias Delux.Support.FakeLEDs
 
+  test "starting Delux with an empty config" do
+    # This is useful for projects that have LEDs on some devices, but not on others.
+    pid = start_supervised!(Delux)
+
+    Delux.render(pid, Delux.Effects.blink(:green, 2))
+  end
+
   @tag :tmp_dir
   test "single LED configuration", %{tmp_dir: led_dir} do
     FakeLEDs.create_leds(led_dir, 1)


### PR DESCRIPTION
This makes it easier to implement a generic LED configuration for
projects that target a range of hardware.
