### PR TITLE
Insert timing padding for Morse code

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,12 @@ It sets up two RGB LEDs and makes one blink early in the boot process.
 };
 ```
 
+### Morse code
+
+Sending Morse code accurately requires a higher kernel timer resolution than
+what may ship in the stock Nerves system for your target. It is recommended to
+set `CONFIG_HZ_1000=y`.
+
 ## License
 
 ```text

--- a/lib/delux/morse.ex
+++ b/lib/delux/morse.ex
@@ -120,6 +120,7 @@ defmodule Delux.Morse do
     for word <- words do
       [morse_word(word, dot_ms), {0, word_ms}, {0, 0}]
     end
+    |> List.insert_at(-1, [{0, word_ms}, {0, 0}])
     |> List.flatten()
   end
 

--- a/test/delux/morse_test.exs
+++ b/test/delux/morse_test.exs
@@ -34,13 +34,15 @@ defmodule Delux.MorseTest do
              {1, 180},
              {1, 0},
              {0, 420},
+             {0, 0},
+             {0, 420},
              {0, 0}
            ]
 
-    assert p.green == [{0, 1680}, {0, 0}]
-    assert p.blue == [{0, 1680}, {0, 0}]
+    assert p.green == [{0, 2100}, {0, 0}]
+    assert p.blue == [{0, 2100}, {0, 0}]
 
-    assert p.duration == 1680
+    assert p.duration == 2100
     assert Program.text_description(p) == "Morse code: TEST"
   end
 
@@ -48,7 +50,7 @@ defmodule Delux.MorseTest do
     p = Morse.encode(:green, "E E E", words_per_minute: 20)
 
     # .<word gap>.<word gap>.
-    assert p.red == [{0, 1440}, {0, 0}]
+    assert p.red == [{0, 1860}, {0, 0}]
 
     assert p.green == [
              {1, 60},
@@ -62,12 +64,14 @@ defmodule Delux.MorseTest do
              {1, 60},
              {1, 0},
              {0, 420},
+             {0, 0},
+             {0, 420},
              {0, 0}
            ]
 
-    assert p.blue == [{0, 1440}, {0, 0}]
+    assert p.blue == [{0, 1860}, {0, 0}]
 
-    assert p.duration == 1440
+    assert p.duration == 1860
     assert Program.text_description(p) == "Morse code: E E E"
   end
 end


### PR DESCRIPTION
Resolves #2 

This PR adds padding after the last character in a Morse code pattern. This helps account for the imprecision in a timer firing when the sequence ends.

I tested this at 5, 25, and 30 words per minute, 5 and 30 being the practical limits of what anyone would likely use.

Old timing example (letter truncated):

![image](https://user-images.githubusercontent.com/4755047/185775302-c03ab2a5-882c-415b-9d13-fdd7dfc7dd09.png)

New timing example:

![image](https://user-images.githubusercontent.com/4755047/185775240-3803dbfc-6fdd-4c56-abb7-602217c5c8bd.png)
