### PR TITLE
Manually expand default arguments to `render/3` and `info/2`

### DIFF
--- a/lib/delux.ex
+++ b/lib/delux.ex
@@ -85,6 +85,26 @@ defmodule Delux do
   end
 
   @doc """
+  Helper for rendering a program when using Delux's defaults
+
+  This calls `render/3` using the default Delux GenServer and default priority.
+  """
+  @spec render(%{indicator_name() => Program.t() | nil} | Program.t() | nil) :: :ok
+  def render(program) when is_map(program) or is_nil(program) do
+    render(__MODULE__, program, @default_priority)
+  end
+
+  @doc """
+  Helper for rendering a program at a priority
+
+  This calls `render/3` using the default Delux GenServer.
+  """
+  @spec render(%{indicator_name() => Program.t() | nil} | Program.t() | nil, priority()) :: :ok
+  def render(program, priority) when (is_map(program) or is_nil(program)) and is_atom(priority) do
+    render(__MODULE__, program, priority)
+  end
+
+  @doc """
   Update one or more indicators to a new program
 
   Passing `nil` for the program removes the program running at the specified
@@ -95,7 +115,6 @@ defmodule Delux do
           %{indicator_name() => Program.t() | nil} | Program.t() | nil,
           priority()
         ) :: :ok
-  def render(server \\ __MODULE__, program, priority \\ @default_priority)
 
   def render(server, %Program{} = program, priority) when is_atom(priority) do
     with {:error, reason} <-
@@ -142,21 +161,45 @@ defmodule Delux do
   end
 
   @doc """
+  Call `info/2` with the defaults
+  """
+  @spec info() :: :ok
+  def info(), do: info(__MODULE__, @default_indicator)
+
+  @doc """
+  Call `info/2` with the specified indicator
+  """
+  @spec info(indicator_name()) :: :ok
+  def info(indicator), do: info(__MODULE__, indicator)
+
+  @doc """
   Print out info about an indicator
 
   This is handy when you can't physically see an indicator. It's intended for
   users at the IEx prompt. For programmatic use, see `info_as_ansidata/2`.
   """
-  @spec info(GenServer.server(), indicator_name()) :: IO.ANSI.ansidata()
-  def info(server \\ __MODULE__, indicator \\ @default_indicator) do
+  @spec info(GenServer.server(), indicator_name()) :: :ok
+  def info(server, indicator) do
     info_as_ansidata(server, indicator) |> IO.ANSI.format() |> IO.puts()
   end
+
+  @doc """
+  Call `info_as_ansidata/2` with the defaults
+  """
+  @spec info_as_ansidata() :: IO.ANSI.ansidata()
+  def info_as_ansidata(), do: info_as_ansidata(__MODULE__, @default_indicator)
+
+  @doc """
+  Call `info_as_ansidata/2` with the specified indicator
+  """
+  @spec info_as_ansidata(indicator_name()) :: IO.ANSI.ansidata()
+  def info_as_ansidata(indicator), do: info_as_ansidata(__MODULE__, indicator)
 
   @doc """
   Return user-readable information about an indicator
   """
   @spec info_as_ansidata(GenServer.server(), indicator_name()) :: IO.ANSI.ansidata()
-  def info_as_ansidata(server \\ __MODULE__, indicator \\ @default_indicator) do
+  def info_as_ansidata(server, indicator) do
     case GenServer.call(server, {:info, indicator}) do
       {:ok, result} -> result
       {:error, reason} -> raise reason

--- a/test/delux_test.exs
+++ b/test/delux_test.exs
@@ -7,7 +7,7 @@ defmodule DeluxTest do
     # This is useful for projects that have LEDs on some devices, but not on others.
     pid = start_supervised!({Delux, name: nil})
 
-    Delux.render(pid, Delux.Effects.blink(:green, 2))
+    Delux.render(pid, Delux.Effects.blink(:green, 2), :status)
   end
 
   @tag :tmp_dir
@@ -19,14 +19,14 @@ defmodule DeluxTest do
         {Delux, name: nil, led_path: led_dir, indicators: %{default: %{green: "led0"}}}
       )
 
-    assert info_as_binary(pid) == "off"
+    assert info_as_binary(pid, :default) == "off"
 
     # Check initialized to off
     assert FakeLEDs.read_trigger(0) == "pattern"
     assert FakeLEDs.read_pattern(0) == "0 3600000 0 0 "
 
     # Blink it
-    Delux.render(pid, Delux.Effects.blink(:green, 2))
+    Delux.render(pid, Delux.Effects.blink(:green, 2), :status)
     assert info_as_binary(pid) == "green at 2 Hz"
     assert FakeLEDs.read_pattern(0) == "1 250 1 0 0 250 0 0 "
 
@@ -56,14 +56,14 @@ defmodule DeluxTest do
     assert FakeLEDs.read_pattern(2) == "0 3600000 0 0 "
 
     # Blink it
-    Delux.render(pid, Delux.Effects.blink(:magenta, 2))
+    Delux.render(pid, Delux.Effects.blink(:magenta, 2), :status)
     assert info_as_binary(pid) == "magenta at 2 Hz"
     assert FakeLEDs.read_pattern(0) == "1 250 1 0 0 250 0 0 "
     assert FakeLEDs.read_pattern(1) == "0 3600000 0 0 "
     assert FakeLEDs.read_pattern(2) == "1 250 1 0 0 250 0 0 "
 
     # Clear it the shortcut way"
-    Delux.render(pid, nil)
+    Delux.render(pid, nil, :status)
     assert info_as_binary(pid) == "off"
     assert FakeLEDs.read_pattern(0) == "0 3600000 0 0 "
     assert FakeLEDs.read_pattern(1) == "0 3600000 0 0 "
@@ -121,7 +121,7 @@ defmodule DeluxTest do
     assert info_as_binary(pid) == "off"
 
     # Blip it
-    Delux.render(pid, Delux.Effects.blip(:green, :black))
+    Delux.render(pid, Delux.Effects.blip(:green, :black), :status)
     assert info_as_binary(pid) == "green->black blip"
     assert FakeLEDs.read_pattern(0) == "0 10 0 0 1 20 1 0 0 3600000 0 0 "
 
@@ -157,7 +157,7 @@ defmodule DeluxTest do
     end
 
     # Blink the default indicator
-    Delux.render(pid, Delux.Effects.blink(:magenta, 2))
+    Delux.render(pid, Delux.Effects.blink(:magenta, 2), :status)
     assert info_as_binary(pid) == "magenta at 2 Hz"
     assert info_as_binary(pid, :indicator2) == "off"
     assert FakeLEDs.read_pattern(0) == "1 250 1 0 0 250 0 0 "
@@ -168,7 +168,7 @@ defmodule DeluxTest do
     assert FakeLEDs.read_pattern(5) == "0 3600000 0 0 "
 
     # Start a second blink on indicator2
-    Delux.render(pid, %{indicator2: Delux.Effects.blink(:blue, 1)})
+    Delux.render(pid, %{indicator2: Delux.Effects.blink(:blue, 1)}, :status)
     assert info_as_binary(pid) == "magenta at 2 Hz"
     assert info_as_binary(pid, :indicator2) == "blue at 1 Hz"
     assert FakeLEDs.read_pattern(0) == "1 250 1 0 0 250 0 0 "
@@ -179,7 +179,7 @@ defmodule DeluxTest do
     assert FakeLEDs.read_pattern(5) == "1 500 1 0 0 500 0 0 "
 
     # Turn off the first blink
-    Delux.render(pid, %{default: nil})
+    Delux.render(pid, %{default: nil}, :status)
     assert info_as_binary(pid) == "off"
     assert info_as_binary(pid, :indicator2) == "blue at 1 Hz"
     assert FakeLEDs.read_pattern(0) == "0 3600000 0 0 "
@@ -190,7 +190,7 @@ defmodule DeluxTest do
     assert FakeLEDs.read_pattern(5) == "1 500 1 0 0 500 0 0 "
 
     # Turn off the second blink
-    Delux.render(pid, %{indicator2: nil})
+    Delux.render(pid, %{indicator2: nil}, :status)
     assert info_as_binary(pid) == "off"
     assert info_as_binary(pid, :indicator2) == "off"
 
@@ -223,7 +223,7 @@ defmodule DeluxTest do
       )
 
     assert_raise ArgumentError, fn ->
-      Delux.render(pid, %{my_indicator: Delux.Effects.on(:green)})
+      Delux.render(pid, %{my_indicator: Delux.Effects.on(:green)}, :status)
     end
   end
 
@@ -281,7 +281,7 @@ defmodule DeluxTest do
     assert FakeLEDs.read_pattern(0) == "0 3600000 0 0 "
 
     # Blink it
-    Delux.render(MyDelux, Delux.Effects.blink(:green, 2))
+    Delux.render(MyDelux, Delux.Effects.blink(:green, 2), :status)
     assert info_as_binary(MyDelux) == "green at 2 Hz"
     assert FakeLEDs.read_pattern(0) == "1 250 1 0 0 250 0 0 "
 


### PR DESCRIPTION
Since it's easiest to use the default GenServer, this makes sure that
the functions that take fewer arguments prefer the non-GenServer ones.
Using the default way that default arguments are expanded, you need to
specify the GenServer or an argument that's definitely not a pid or
GenServer name will be used for the GenServer. This is a little
confusing when you first see it and less convenient.
