### PR TITLE
Adjust timing calculations for accuracy on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,26 @@ See Linux's LED pattern trigger documentation at
 [leds-trigger-pattern.txt](https://elixir.bootlin.com/linux/v5.19/source/Documentation/devicetree/bindings/leds/leds-trigger-pattern.txt)
 for more info.
 
+## Timing precision
+
+The Linux kernel's `HZ` configuration sets the granularity at which Delux can
+render patterns. For example, if `HZ=100`, the timing resolution is 10 ms. The
+kernel also adds a start delay for any pattern. Delux can compensate for both
+effects to more accurately render programs. This is ultimately limited to the
+timer resolution so if the system only supports 10 ms resolution, that's the
+best that Delux can do.
+
+Delux can't automatically detect the `HZ` setting so it must be told via the
+`:backend` options:
+
+```elixir
+Delux.start_link(backend: [hz: 100], indicators: %{default: %{green: "led0"}})
+```
+
+If you need better resolution, you'l need to update the Linux kernel
+configuration with `CONFIG_HZ=1000` and rebuild. Be sure to update the `:hz`
+value passed to `Delux` so that the compensation is calculated correctly.
+
 ## Linux kernel configuration
 
 `delux` works in all official Nerves systems. If not using Nerves, you will

--- a/README.md
+++ b/README.md
@@ -224,6 +224,15 @@ If you need better resolution, you'l need to update the Linux kernel
 configuration with `CONFIG_HZ=1000` and rebuild. Be sure to update the `:hz`
 value passed to `Delux` so that the compensation is calculated correctly.
 
+To verify timing, connect a logic analyzer to an LED controlled by Delux and
+run this:
+
+```elixir
+Delux.render(Delux.Effects.timing_test(:on))
+```
+
+See `Delux.Effects.timing_test/2` for details on what you should see.
+
 ## Linux kernel configuration
 
 `delux` works in all official Nerves systems. If not using Nerves, you will

--- a/lib/delux.ex
+++ b/lib/delux.ex
@@ -389,8 +389,12 @@ defmodule Delux do
   defp refresh_indicators(state) do
     summarized = summarize_programs(state)
 
-    Enum.each(summarized, fn {indicator, program} ->
-      Glue.set_program!(state.glue[indicator], program, state.brightness)
+    Enum.reduce(summarized, state.glue, fn {indicator, program}, glue_state ->
+      indicator_state = glue_state[indicator]
+      {compiled, _duration} = Glue.compile_program!(indicator_state, program, state.brightness)
+
+      new_indicator_state = Glue.set_program(indicator_state, compiled)
+      Map.put(glue_state, indicator, new_indicator_state)
     end)
   end
 

--- a/lib/delux/backend.ex
+++ b/lib/delux/backend.ex
@@ -185,13 +185,13 @@ defmodule Delux.Backend do
   @spec hz_comp_250(pos_integer()) :: {pos_integer(), pos_integer()}
   def hz_comp_250(0), do: {0, 0}
   def hz_comp_250(duration) when duration < 7, do: {1, 8}
-  def hz_comp_250(duration), do: {duration - 6, 4 + :math.ceil((duration - 6) / 4) * 4}
+  def hz_comp_250(duration), do: {duration - 6, div(duration - 6 + 7, 4) * 4}
 
   @doc false
   @spec hz_comp_100(pos_integer()) :: {pos_integer(), pos_integer()}
   def hz_comp_100(0), do: {0, 0}
   def hz_comp_100(duration) when duration < 16, do: {1, 20}
-  def hz_comp_100(duration), do: {duration - 15, 10 + :math.ceil((duration - 15) / 10) * 10}
+  def hz_comp_100(duration), do: {duration - 15, div(duration - 15 + 19, 10) * 10}
 
   defp hz_comp_none(duration), do: {duration, duration}
 

--- a/lib/delux/effects.ex
+++ b/lib/delux/effects.ex
@@ -83,6 +83,90 @@ defmodule Delux.Effects do
   end
 
   @doc """
+  Create a program to verify timing
+
+  If you're unsure about the playback timing on your device, hook up a logic
+  analyzer to an LED and capture the waveform. Here's what you should see:
+
+  1. 100 ms on
+  2. 10 ms off
+  3. 1 ms on
+  4. 10 ms off
+  5. 2 ms on
+  6. 10 ms off
+  7. 3 ms on
+  8. 10 ms off
+  9. 5 ms on
+  10. 10 ms off
+  11. 8 ms on
+  12. 10 ms off
+  13. 13 ms on
+  14. 10 ms off
+  15. 100 ms on
+  16. off
+
+  Look at the following in the capture:
+
+  1. Do the 1, 2, 3, 5 ms captures match what you'd expect based on your
+     kernel's HZ setting. For example, if HZ=100, they should all be 10 ms long.
+     If not, check the :hz setting for Delux.
+  2. Does the length of the final 100 ms on time match the first. If not,
+     Delux might be calculating the duration wrong and cutting off the program
+     prematurely. This is likely due to an incorrect :hz setting.
+
+  If something still isn't right, please submit an issue with the captured
+  waveform and any other hints you may have to reproduce.
+  """
+  @spec timing_test(RGB.color(), common_options()) :: Program.t()
+  def timing_test(c, _options \\ []) do
+    {r, g, b} = RGB.new(c)
+
+    %Program{
+      red: led_timing(r),
+      green: led_timing(g),
+      blue: led_timing(b),
+      description: ["Timing test pattern in ", RGB.to_ansidata(c)],
+      mode: :one_shot
+    }
+  end
+
+  defp led_timing(0), do: led_off()
+
+  defp led_timing(b),
+    do: [
+      {b, 100},
+      {b, 0},
+      {0, 10},
+      {0, 0},
+      {b, 1},
+      {b, 0},
+      {0, 10},
+      {0, 0},
+      {b, 2},
+      {b, 0},
+      {0, 10},
+      {0, 0},
+      {b, 3},
+      {b, 0},
+      {0, 10},
+      {0, 0},
+      {b, 5},
+      {b, 0},
+      {0, 10},
+      {0, 0},
+      {b, 8},
+      {b, 0},
+      {0, 10},
+      {0, 0},
+      {b, 13},
+      {b, 0},
+      {0, 10},
+      {0, 0},
+      {b, 100},
+      {b, 0}
+    ]
+
+  @doc """
   Cycle between colors
 
   Colors are shown with equal duration determined from the specified frequency.

--- a/lib/delux/effects.ex
+++ b/lib/delux/effects.ex
@@ -7,8 +7,6 @@ defmodule Delux.Effects do
   alias Delux.Program
   alias Delux.RGB
 
-  @long_time 3_600_000
-
   @typedoc """
   Options for all effects (none yet)
   """
@@ -24,7 +22,7 @@ defmodule Delux.Effects do
       green: led_off(),
       blue: led_off(),
       description: "off",
-      duration: :infinity
+      mode: :simple_loop
     }
   end
 
@@ -40,7 +38,7 @@ defmodule Delux.Effects do
       green: led_on(g),
       blue: led_on(b),
       description: RGB.to_ansidata(c, "solid "),
-      duration: :infinity
+      mode: :simple_loop
     }
   end
 
@@ -59,7 +57,7 @@ defmodule Delux.Effects do
       green: led_blink(g, frequency),
       blue: led_blink(b, frequency),
       description: [RGB.to_ansidata(c, ""), " at #{frequency} Hz"],
-      duration: :infinity
+      mode: :simple_loop
     }
   end
 
@@ -80,7 +78,7 @@ defmodule Delux.Effects do
       green: led_blip(g1, g2),
       blue: led_blip(b1, b2),
       description: [RGB.to_ansidata(c1), :reset, "->", RGB.to_ansidata(c2), " blip"],
-      duration: 40
+      mode: :one_shot
     }
   end
 
@@ -105,7 +103,7 @@ defmodule Delux.Effects do
         :reset,
         " cycle at #{frequency} Hz"
       ],
-      duration: :infinity
+      mode: :simple_loop
     }
   end
 
@@ -140,7 +138,7 @@ defmodule Delux.Effects do
       green: led_waveform(greens, time_step, period),
       blue: led_waveform(blues, time_step, period),
       description: "waveform",
-      duration: :infinity
+      mode: :simple_loop
     }
   end
 
@@ -177,7 +175,7 @@ defmodule Delux.Effects do
       green: led_number_blink(g, count, on, off, inter),
       blue: led_number_blink(b, count, on, off, inter),
       description: ["Blink ", RGB.to_ansidata(c, ""), " #{count} times"],
-      duration: :infinity
+      mode: :simple_loop
     }
   end
 
@@ -192,8 +190,8 @@ defmodule Delux.Effects do
   defp unzip3([], {a1, a2, a3}), do: {Enum.reverse(a1), Enum.reverse(a2), Enum.reverse(a3)}
   defp unzip3([{x, y, z} | rest], {a1, a2, a3}), do: unzip3(rest, {[x | a1], [y | a2], [z | a3]})
 
-  defp led_off(), do: [{0, @long_time}, {0, 0}]
-  defp led_on(b), do: [{b, @long_time}, {b, 0}]
+  defp led_off(), do: [{0, Pattern.forever_ms()}, {0, 0}]
+  defp led_on(b), do: [{b, Pattern.forever_ms()}, {b, 0}]
   defp led_blink(0, _frequency), do: led_off()
 
   defp led_blink(b, frequency) when frequency > 0 and frequency < 20 do
@@ -204,9 +202,9 @@ defmodule Delux.Effects do
   defp led_blink(b, frequency) when frequency >= 20, do: led_on(b)
 
   defp led_blip(0, 0), do: led_off()
-  defp led_blip(0, b2), do: [{0, 20}, {0, 0}, {b2, 20}, {b2, 0} | led_off()]
-  defp led_blip(b1, 0), do: [{0, 10}, {0, 0}, {b1, 20}, {b1, 0} | led_off()]
-  defp led_blip(b1, b2), do: [{0, 10}, {0, 0}, {b1, 30}, {b2, 0} | led_off()]
+  defp led_blip(0, b2), do: [{0, 20}, {0, 0}, {b2, 20}, {b2, 0}]
+  defp led_blip(b1, 0), do: [{0, 10}, {0, 0}, {b1, 20}, {b1, 0}]
+  defp led_blip(b1, b2), do: [{0, 10}, {0, 0}, {b1, 30}, {b2, 0}]
 
   defp led_cycle(values, duration) do
     Enum.flat_map(values, fn b -> [{b, duration}, {b, 0}] end)

--- a/lib/delux/glue.ex
+++ b/lib/delux/glue.ex
@@ -10,7 +10,8 @@ defmodule Delux.Glue do
           blue: File.io_device() | nil,
           red_max: pos_integer(),
           green_max: pos_integer(),
-          blue_max: pos_integer()
+          blue_max: pos_integer(),
+          comp: function()
         }
 
   @typedoc false
@@ -28,10 +29,13 @@ defmodule Delux.Glue do
   * `:green` - the name of the green LED if it exists
   * `:blue` - the name of the blue LED if it exists
   * `:led_path` - the path to the LED files if using a nonstandard path (`"/sys/class/leds"`)
+  * `:hz` - the Linux HZ configuration setting. Valid choices are 0, 100, 250, 300, 1000. Defaults
+    to 1000. 0 means no adjustments for the HZ settings.
   """
   @spec open(keyword() | map()) :: state()
   def open(options) do
     led_path = options[:led_path] || @default_led_path
+    comp = options[:hz] |> validate_hz()
 
     red = options[:red]
     green = options[:green]
@@ -42,6 +46,7 @@ defmodule Delux.Glue do
     {blue_handle, blue_max} = init_handle(led_path, blue)
 
     %{
+      comp: comp,
       red: red_handle,
       green: green_handle,
       blue: blue_handle,
@@ -51,6 +56,13 @@ defmodule Delux.Glue do
     }
   end
 
+  defp validate_hz(1000), do: &hz_comp_1000/1
+  defp validate_hz(300), do: &hz_comp_300/1
+  defp validate_hz(250), do: &hz_comp_250/1
+  defp validate_hz(100), do: &hz_comp_100/1
+  defp validate_hz(0), do: &hz_comp_none/1
+  defp validate_hz(nil), do: &hz_comp_1000/1
+
   @doc """
   Compile an indicator program so that it can be run efficiently later
   """
@@ -58,13 +70,27 @@ defmodule Delux.Glue do
   def compile_program!(%{} = state, %Program{} = program, percent) do
     # Process the patterns for brightness adjustments and convert to iodata
     {r, r_duration} =
-      maybe_prep_iodata(state.red, program.red, percent, state.red_max, program.mode)
+      maybe_prep_iodata(state.red, program.red, percent, state.red_max, state.comp, program.mode)
 
     {g, g_duration} =
-      maybe_prep_iodata(state.green, program.green, percent, state.green_max, program.mode)
+      maybe_prep_iodata(
+        state.green,
+        program.green,
+        percent,
+        state.green_max,
+        state.comp,
+        program.mode
+      )
 
     {b, b_duration} =
-      maybe_prep_iodata(state.blue, program.blue, percent, state.blue_max, program.mode)
+      maybe_prep_iodata(
+        state.blue,
+        program.blue,
+        percent,
+        state.blue_max,
+        state.comp,
+        program.mode
+      )
 
     duration =
       case program.mode do
@@ -93,15 +119,79 @@ defmodule Delux.Glue do
     {state, duration}
   end
 
-  defp maybe_prep_iodata(nil, _sequence, _percent, _max_brightness, _mode),
+  defp maybe_prep_iodata(nil, _sequence, _percent, _max_brightness, _res, _mode),
     do: {nil, Pattern.forever_ms()}
 
-  defp maybe_prep_iodata(_handle, sequence, percent, max_brightness, mode) do
+  defp maybe_prep_iodata(_handle, sequence, percent, max_brightness, res, mode) do
     sequence
     |> Pattern.pwm(percent)
-    |> Pattern.build_iodata(max_brightness)
+    |> pattern_to_iodata(max_brightness, res)
     |> append_trailer(mode)
   end
+
+  @doc """
+  Convert a pattern to iodata
+
+  * `pattern` - the pattern to convert
+  * `max_b` - the max brightness supported by the LED (usually 1 or 255)
+  * `comp` - a function for converting durations to values to pass to Linux
+    and actual durations
+
+  Returns a tuple with the iodata and total duration
+  """
+  @spec pattern_to_iodata(Pattern.t(), non_neg_integer(), function()) ::
+          {iolist(), non_neg_integer()}
+  def pattern_to_iodata(pattern, max_b, comp) do
+    build(pattern, max_b, comp, [], 0)
+  end
+
+  defp build([], _max_b, _comp, acc, total) do
+    {acc, total}
+  end
+
+  defp build([{component, duration} | rest], max_b, comp, acc, total) do
+    brightness = round(component * max_b)
+    {linux_duration, predicted_duration} = comp.(duration)
+    new_total = predicted_duration + total
+    new_acc = [acc, [to_string(brightness), " ", to_string(linux_duration), " "]]
+    build(rest, max_b, comp, new_acc, new_total)
+  end
+
+  # The hz_comp_n/1 functions return {linux_duration, predicted_duration}
+  # The linux_duration is what you tell Linux to get a duration close to what you want.
+  # The predicted_duration is what you'll actually get.
+  # These conversions where determined by measuring the output on an otherwise idle
+  # device using a logic analyzer. The fit was pretty good, so one hopes that this
+  # is a general result across devices.
+  @doc false
+  @spec hz_comp_1000(pos_integer()) :: {pos_integer(), pos_integer()}
+  def hz_comp_1000(0), do: {0, 0}
+  def hz_comp_1000(1), do: {1, 2}
+  def hz_comp_1000(duration), do: {duration - 1, duration}
+
+  @doc false
+  # If anyone actually uses 300 Hz, it needs work since we don't support
+  # sub-millisecond times.
+  @spec hz_comp_300(pos_integer()) :: {pos_integer(), pos_integer()}
+  def hz_comp_300(0), do: {0, 0}
+  def hz_comp_300(duration) when duration < 6, do: {1, 7}
+
+  def hz_comp_300(duration),
+    do: {duration - 5, round(3.3333 + :math.ceil((duration - 5) / 3.3333) * 3.3333)}
+
+  @doc false
+  @spec hz_comp_250(pos_integer()) :: {pos_integer(), pos_integer()}
+  def hz_comp_250(0), do: {0, 0}
+  def hz_comp_250(duration) when duration < 7, do: {1, 8}
+  def hz_comp_250(duration), do: {duration - 6, 4 + :math.ceil((duration - 6) / 4) * 4}
+
+  @doc false
+  @spec hz_comp_100(pos_integer()) :: {pos_integer(), pos_integer()}
+  def hz_comp_100(0), do: {0, 0}
+  def hz_comp_100(duration) when duration < 16, do: {1, 20}
+  def hz_comp_100(duration), do: {duration - 15, 10 + :math.ceil((duration - 15) / 10) * 10}
+
+  defp hz_comp_none(duration), do: {duration, duration}
 
   defp append_trailer({iodata, duration}, :one_shot), do: {[iodata, @led_off], duration}
   defp append_trailer(iodata_and_duration, _), do: iodata_and_duration

--- a/lib/delux/glue.ex
+++ b/lib/delux/glue.ex
@@ -16,13 +16,27 @@ defmodule Delux.Glue do
   @typedoc false
   @type compiled() :: {nil | iodata(), nil | iodata(), nil | iodata(), Pattern.milliseconds()}
 
+  @default_led_path "/sys/class/leds"
+
   @led_off "0 3600000 0 0"
 
   @doc """
   Open and prep file handles for writing patterns
+
+  Options:
+  * `:red` - the name of the red LED if it exists
+  * `:green` - the name of the green LED if it exists
+  * `:blue` - the name of the blue LED if it exists
+  * `:led_path` - the path to the LED files if using a nonstandard path (`"/sys/class/leds"`)
   """
-  @spec open(String.t(), String.t() | nil, String.t() | nil, String.t() | nil) :: state()
-  def open(led_path, red, green, blue) do
+  @spec open(keyword() | map()) :: state()
+  def open(options) do
+    led_path = options[:led_path] || @default_led_path
+
+    red = options[:red]
+    green = options[:green]
+    blue = options[:blue]
+
     {red_handle, red_max} = init_handle(led_path, red)
     {green_handle, green_max} = init_handle(led_path, green)
     {blue_handle, blue_max} = init_handle(led_path, blue)

--- a/lib/delux/morse.ex
+++ b/lib/delux/morse.ex
@@ -2,6 +2,7 @@ defmodule Delux.Morse do
   @moduledoc """
   Functions for Morse code patterns
   """
+
   alias Delux.Program
   alias Delux.RGB
 
@@ -83,7 +84,6 @@ defmodule Delux.Morse do
 
     up_string = String.upcase(string, :ascii)
     base_elements = morse(up_string, words_per_minute)
-
     duration = duration_elements(base_elements)
 
     %Program{
@@ -91,7 +91,7 @@ defmodule Delux.Morse do
       green: elements(g, base_elements, duration),
       blue: elements(b, base_elements, duration),
       description: "Morse code: #{up_string}",
-      duration: duration
+      mode: :one_shot
     }
   end
 

--- a/lib/delux/pattern.ex
+++ b/lib/delux/pattern.ex
@@ -26,13 +26,35 @@ defmodule Delux.Pattern do
 
   @doc """
   Convert a pattern to iodata
+
+  * `pattern` - the pattern to convert
+  * `max_b` - the max brightness supported by the LED (usually 1 or 255)
+
+  Returns a tuple with the iodata and total duration
   """
-  @spec to_iodata(t(), non_neg_integer()) :: iolist()
-  def to_iodata(pattern, max_b) do
-    for {component, duration} <- pattern do
-      [to_string(round(component * max_b)), " ", to_string(duration), " "]
-    end
+  @spec build_iodata(t(), non_neg_integer()) :: {iolist(), non_neg_integer()}
+  def build_iodata(pattern, max_b) do
+    build(pattern, max_b, [], 0)
   end
+
+  defp build([], _max_b, acc, total) do
+    {acc, total}
+  end
+
+  defp build([{component, duration} | rest], max_b, acc, total) do
+    brightness = round(component * max_b)
+    new_total = duration + total
+    new_acc = [acc, [to_string(brightness), " ", to_string(duration), " "]]
+    build(rest, max_b, new_acc, new_total)
+  end
+
+  @doc """
+  Return a number of ms that should be considered a long time
+
+  Linux doesn't support an infinite timeout, so use this value instead.
+  """
+  @spec forever_ms() :: 3_600_000
+  def forever_ms(), do: 3_600_000
 
   @doc """
   PWM a sequence of elements

--- a/lib/delux/pattern.ex
+++ b/lib/delux/pattern.ex
@@ -25,30 +25,6 @@ defmodule Delux.Pattern do
   @type t() :: [element()]
 
   @doc """
-  Convert a pattern to iodata
-
-  * `pattern` - the pattern to convert
-  * `max_b` - the max brightness supported by the LED (usually 1 or 255)
-
-  Returns a tuple with the iodata and total duration
-  """
-  @spec build_iodata(t(), non_neg_integer()) :: {iolist(), non_neg_integer()}
-  def build_iodata(pattern, max_b) do
-    build(pattern, max_b, [], 0)
-  end
-
-  defp build([], _max_b, acc, total) do
-    {acc, total}
-  end
-
-  defp build([{component, duration} | rest], max_b, acc, total) do
-    brightness = round(component * max_b)
-    new_total = duration + total
-    new_acc = [acc, [to_string(brightness), " ", to_string(duration), " "]]
-    build(rest, max_b, new_acc, new_total)
-  end
-
-  @doc """
   Return a number of ms that should be considered a long time
 
   Linux doesn't support an infinite timeout, so use this value instead.

--- a/lib/delux/program.ex
+++ b/lib/delux/program.ex
@@ -8,7 +8,19 @@ defmodule Delux.Program do
   alias Delux.Effects
   alias Delux.Pattern
 
-  defstruct red: [], green: [], blue: [], description: "", duration: :infinity
+  defstruct red: [], green: [], blue: [], description: "", mode: :simple_loop
+
+  @typedoc """
+  Program playback mode
+
+  The playback mode determines what happens when the program gets interrupted
+  or ends.
+
+  * `:simple_loop` - keep repeating the program. If it's interrupted, just
+    restart at the the beginning.
+  * `:one_shot` - run the program once
+  """
+  @type mode() :: :one_shot | :simple_loop
 
   @typedoc """
   Program information for one indicator
@@ -18,7 +30,7 @@ defmodule Delux.Program do
           green: Pattern.t(),
           blue: Pattern.t(),
           description: IO.ANSI.ansidata(),
-          duration: Pattern.milliseconds() | :infinity
+          mode: mode()
         }
 
   @doc """

--- a/test/delux/effects_test.exs
+++ b/test/delux/effects_test.exs
@@ -14,7 +14,7 @@ defmodule Delux.EffectsTest do
       assert off.red == off.green
       assert off.red == off.blue
 
-      assert off.duration == :infinity
+      assert off.mode == :simple_loop
     end
 
     test "description" do
@@ -31,7 +31,7 @@ defmodule Delux.EffectsTest do
       assert pattern.green == [{0, 3_600_000}, {0, 0}]
       assert pattern.red == pattern.blue
 
-      assert pattern.duration == :infinity
+      assert pattern.mode == :simple_loop
     end
 
     test "description" do
@@ -48,7 +48,7 @@ defmodule Delux.EffectsTest do
       assert pattern.green == [{0, 3_600_000}, {0, 0}]
       assert pattern.blue == [{1, 250}, {1, 0}, {0, 250}, {0, 0}]
 
-      assert pattern.duration == :infinity
+      assert pattern.mode == :simple_loop
     end
 
     test "blinking too fast is solid on" do
@@ -77,11 +77,11 @@ defmodule Delux.EffectsTest do
     test "build a blip" do
       pattern = Effects.blip(:red, :green)
 
-      assert pattern.red == [{0, 10}, {0, 0}, {1, 20}, {1, 0}, {0, 3_600_000}, {0, 0}]
-      assert pattern.green == [{0, 20}, {0, 0}, {1, 20}, {1, 0}, {0, 3_600_000}, {0, 0}]
+      assert pattern.red == [{0, 10}, {0, 0}, {1, 20}, {1, 0}]
+      assert pattern.green == [{0, 20}, {0, 0}, {1, 20}, {1, 0}]
       assert pattern.blue == [{0, 3_600_000}, {0, 0}]
 
-      assert pattern.duration == 40
+      assert pattern.mode == :one_shot
     end
 
     test "description" do
@@ -98,7 +98,7 @@ defmodule Delux.EffectsTest do
       assert pattern.green == [{0, 333}, {0, 0}, {1, 333}, {1, 0}, {0, 333}, {0, 0}]
       assert pattern.blue == [{0, 333}, {0, 0}, {0, 333}, {0, 0}, {1, 333}, {1, 0}]
 
-      assert pattern.duration == :infinity
+      assert pattern.mode == :simple_loop
     end
 
     test "description" do
@@ -124,7 +124,7 @@ defmodule Delux.EffectsTest do
       assert p.red == [{0, 2000}, {0, 0}]
       assert p.green == [{0, 2000}, {0, 0}]
 
-      assert p.duration == :infinity
+      assert p.mode == :simple_loop
     end
 
     test "triangle that uses time_step" do
@@ -178,7 +178,7 @@ defmodule Delux.EffectsTest do
       assert pattern.green == [{0, 3_600_000}, {0, 0}]
       assert pattern.blue == [{0, 3_600_000}, {0, 0}]
 
-      assert pattern.duration == :infinity
+      assert pattern.mode == :simple_loop
     end
 
     test "custom blink out 5" do
@@ -218,7 +218,7 @@ defmodule Delux.EffectsTest do
       assert pattern.green == expected_pattern
       assert pattern.blue == expected_pattern
 
-      assert pattern.duration == :infinity
+      assert pattern.mode == :simple_loop
     end
 
     test "description" do

--- a/test/delux/effects_test.exs
+++ b/test/delux/effects_test.exs
@@ -226,4 +226,32 @@ defmodule Delux.EffectsTest do
       assert Program.text_description(pattern) == "Blink green 10 times"
     end
   end
+
+  describe "timing_test/3" do
+    test "build a timing test" do
+      pattern = Effects.timing_test(:red)
+
+      {header, middle} = Enum.split(pattern.red, 2)
+      {middle, trailer} = Enum.split(middle, -2)
+
+      # starts and ends with 100 ms
+      assert header == [{1, 100}, {1, 0}]
+      assert trailer == [{1, 100}, {1, 0}]
+
+      # middle only has 10 ms off times
+      assert Enum.any?(middle, fn {x, duration} ->
+               x == 0 and (duration != 0 or duration != 10)
+             end)
+
+      assert pattern.green == [{0, 3_600_000}, {0, 0}]
+      assert pattern.blue == [{0, 3_600_000}, {0, 0}]
+
+      assert pattern.mode == :one_shot
+    end
+
+    test "description" do
+      pattern = Effects.timing_test(:red)
+      assert Program.text_description(pattern) == "Timing test pattern in red"
+    end
+  end
 end

--- a/test/delux/glue_test.exs
+++ b/test/delux/glue_test.exs
@@ -6,14 +6,18 @@ defmodule Delux.GlueTest do
 
   doctest Glue
 
+  defp compile_and_set(state, program, percent) do
+    {compiled, _duration} = Glue.compile_program!(state, program, percent)
+    Glue.set_program(state, compiled)
+  end
+
   @tag :tmp_dir
   test "correctly writes to led files", %{tmp_dir: led_dir} do
     FakeLEDs.create_leds(led_dir, 255)
 
-    state = Glue.open(led_dir, "led0", "led1", "led2")
-    Glue.set_program!(state, Delux.Effects.blink(:red, 5), 100)
-
-    Glue.close(state)
+    Glue.open(led_dir, "led0", "led1", "led2")
+    |> compile_and_set(Delux.Effects.blink(:red, 5), 100)
+    |> Glue.close()
 
     assert FakeLEDs.read_trigger(0) == "pattern"
     assert FakeLEDs.read_trigger(1) == "pattern"
@@ -29,11 +33,9 @@ defmodule Delux.GlueTest do
     FakeLEDs.create_leds(led_dir, 255)
 
     # Only configure a green LED, but run a blinking white program
-    state = Glue.open(led_dir, nil, "led0", nil)
-
-    Glue.set_program!(state, Delux.Effects.blink(:white, 1), 100)
-
-    Glue.close(state)
+    Glue.open(led_dir, nil, "led0", nil)
+    |> compile_and_set(Delux.Effects.blink(:white, 1), 100)
+    |> Glue.close()
 
     # Verify that only "led0" is configured and written
     assert FakeLEDs.read_trigger(0) == "pattern"

--- a/test/delux/glue_test.exs
+++ b/test/delux/glue_test.exs
@@ -19,7 +19,7 @@ defmodule Delux.GlueTest do
   test "correctly writes to led files", %{tmp_dir: led_dir} do
     FakeLEDs.create_leds(led_dir, 255)
 
-    Glue.open(led_dir, "led0", "led1", "led2")
+    Glue.open(led_path: led_dir, red: "led0", green: "led1", blue: "led2")
     |> compile_and_set(Delux.Effects.blink(:red, 5), 100, 3_600_000)
     |> Glue.close()
 
@@ -37,7 +37,7 @@ defmodule Delux.GlueTest do
     FakeLEDs.create_leds(led_dir, 255)
 
     # Only configure a green LED, but run a blinking white program
-    Glue.open(led_dir, nil, "led0", nil)
+    Glue.open(led_path: led_dir, green: "led0")
     |> compile_and_set(Delux.Effects.blink(:white, 1), 100, 3_600_000)
     |> Glue.close()
 
@@ -55,7 +55,7 @@ defmodule Delux.GlueTest do
   test "calculates duration of non-repeating patterns", %{tmp_dir: led_dir} do
     FakeLEDs.create_leds(led_dir, 255)
 
-    state = Glue.open(led_dir, nil, "led0", nil)
+    state = Glue.open(led_path: led_dir, green: "led0")
 
     compile_and_set(state, Delux.Effects.blip(:green, :green), 100, 40)
 

--- a/test/delux/glue_test.exs
+++ b/test/delux/glue_test.exs
@@ -1,6 +1,7 @@
 defmodule Delux.GlueTest do
   use ExUnit.Case, async: true
 
+  alias Delux.Effects
   alias Delux.Glue
   alias Delux.Support.FakeLEDs
 
@@ -19,7 +20,7 @@ defmodule Delux.GlueTest do
   test "correctly writes to led files", %{tmp_dir: led_dir} do
     FakeLEDs.create_leds(led_dir, 255)
 
-    Glue.open(led_path: led_dir, red: "led0", green: "led1", blue: "led2")
+    Glue.open(led_path: led_dir, hz: 0, red: "led0", green: "led1", blue: "led2")
     |> compile_and_set(Delux.Effects.blink(:red, 5), 100, 3_600_000)
     |> Glue.close()
 
@@ -37,7 +38,7 @@ defmodule Delux.GlueTest do
     FakeLEDs.create_leds(led_dir, 255)
 
     # Only configure a green LED, but run a blinking white program
-    Glue.open(led_path: led_dir, green: "led0")
+    Glue.open(led_path: led_dir, hz: 0, green: "led0")
     |> compile_and_set(Delux.Effects.blink(:white, 1), 100, 3_600_000)
     |> Glue.close()
 
@@ -60,5 +61,184 @@ defmodule Delux.GlueTest do
     compile_and_set(state, Delux.Effects.blip(:green, :green), 100, 40)
 
     Glue.close(state)
+  end
+
+  @tag :tmp_dir
+  test "specifying hz", %{tmp_dir: led_dir} do
+    FakeLEDs.create_leds(led_dir, 255)
+
+    Glue.open(led_path: led_dir, hz: 100, red: "led0", green: "led1", blue: "led2")
+    |> compile_and_set(Delux.Effects.blink(:red, 5), 100, 3_600_000)
+    |> Glue.close()
+
+    assert FakeLEDs.read_trigger(0) == "pattern"
+    assert FakeLEDs.read_trigger(1) == "pattern"
+    assert FakeLEDs.read_trigger(2) == "pattern"
+
+    assert FakeLEDs.read_pattern(0) == "255 85 255 0 0 85 0 0 "
+    assert FakeLEDs.read_pattern(1) == "0 3599985 0 0 "
+    assert FakeLEDs.read_pattern(2) == "0 3599985 0 0 "
+  end
+
+  @tag :tmp_dir
+  test "default hz adjusts for 1000 hz", %{tmp_dir: led_dir} do
+    FakeLEDs.create_leds(led_dir, 255)
+
+    Glue.open(led_path: led_dir, red: "led0", green: "led1", blue: "led2")
+    |> compile_and_set(Delux.Effects.blink(:red, 5), 100, 3_600_000)
+    |> Glue.close()
+
+    assert FakeLEDs.read_trigger(0) == "pattern"
+    assert FakeLEDs.read_trigger(1) == "pattern"
+    assert FakeLEDs.read_trigger(2) == "pattern"
+
+    assert FakeLEDs.read_pattern(0) == "255 99 255 0 0 99 0 0 "
+    assert FakeLEDs.read_pattern(1) == "0 3599999 0 0 "
+    assert FakeLEDs.read_pattern(2) == "0 3599999 0 0 "
+  end
+
+  describe "pattern_to_iodata/2" do
+    test "simple conversions" do
+      assert pattern_to_binary(Effects.off().red) == "0 3600000 0 0 "
+      assert pattern_to_binary(Effects.blink(:red, 2).red) == "1 250 1 0 0 250 0 0 "
+    end
+
+    test "scaled to LED max brightness" do
+      assert pattern_to_binary(Effects.blink(:red, 2).red, 255) == "255 250 255 0 0 250 0 0 "
+    end
+  end
+
+  defp pattern_to_binary(pattern, brightness \\ 1) do
+    {iodata, _duration} = Glue.pattern_to_iodata(pattern, brightness, fn x -> {x, x} end)
+    IO.iodata_to_binary(iodata)
+  end
+
+  test "hz_comp_1000" do
+    measured = [
+      {0, 0},
+      {1, 2},
+      {1, 2},
+      {2, 3},
+      {3, 4},
+      {4, 5},
+      {5, 6},
+      {6, 7},
+      {7, 8},
+      {8, 9},
+      {9, 10},
+      {10, 11}
+    ]
+
+    measured
+    |> Enum.with_index()
+    |> Enum.each(fn {result, input} ->
+      assert Glue.hz_comp_1000(input) == result
+    end)
+  end
+
+  test "hz_comp_300" do
+    # If you're really using 300 Hz and you don't want to switch, please let me know.
+    guessed = [
+      {0, 0},
+      {1, 7},
+      {1, 7},
+      {1, 7},
+      {1, 7},
+      {1, 7},
+      {1, 7},
+      {2, 7},
+      {3, 7},
+      {4, 10},
+      {5, 10},
+      {6, 10}
+    ]
+
+    guessed
+    |> Enum.with_index()
+    |> Enum.each(fn {result, input} ->
+      assert Glue.hz_comp_300(input) == result
+    end)
+  end
+
+  test "hz_comp_250" do
+    measured = [
+      {0, 0},
+      {1, 8},
+      {1, 8},
+      {1, 8},
+      {1, 8},
+      {1, 8},
+      {1, 8},
+      {1, 8},
+      {2, 8},
+      {3, 8},
+      {4, 8},
+      {5, 12},
+      {6, 12},
+      {7, 12},
+      {8, 12},
+      {9, 16},
+      {10, 16},
+      {11, 16},
+      {12, 16},
+      {13, 20},
+      {14, 20},
+      {15, 20},
+      {16, 20}
+    ]
+
+    measured
+    |> Enum.with_index()
+    |> Enum.each(fn {result, input} ->
+      assert Glue.hz_comp_250(input) == result
+    end)
+  end
+
+  test "hz_comp_100" do
+    measured = [
+      {0, 0},
+      {1, 20},
+      {1, 20},
+      {1, 20},
+      {1, 20},
+      {1, 20},
+      {1, 20},
+      {1, 20},
+      {1, 20},
+      {1, 20},
+      {1, 20},
+      {1, 20},
+      {1, 20},
+      {1, 20},
+      {1, 20},
+      {1, 20},
+      {1, 20},
+      {2, 20},
+      {3, 20},
+      {4, 20},
+      {5, 20},
+      {6, 20},
+      {7, 20},
+      {8, 20},
+      {9, 20},
+      {10, 20},
+      {11, 30},
+      {12, 30},
+      {13, 30},
+      {14, 30},
+      {15, 30},
+      {16, 30},
+      {17, 30},
+      {18, 30},
+      {19, 30},
+      {20, 30},
+      {21, 40}
+    ]
+
+    measured
+    |> Enum.with_index()
+    |> Enum.each(fn {result, input} ->
+      assert Glue.hz_comp_100(input) == result
+    end)
   end
 end

--- a/test/delux/morse_test.exs
+++ b/test/delux/morse_test.exs
@@ -40,7 +40,7 @@ defmodule Delux.MorseTest do
     assert p.green == [{0, 1680}, {0, 0}]
     assert p.blue == [{0, 1680}, {0, 0}]
 
-    assert p.duration == 1680
+    assert p.mode == :one_shot
     assert Program.text_description(p) == "Morse code: TEST"
   end
 
@@ -67,7 +67,7 @@ defmodule Delux.MorseTest do
 
     assert p.blue == [{0, 1440}, {0, 0}]
 
-    assert p.duration == 1440
+    assert p.mode == :one_shot
     assert Program.text_description(p) == "Morse code: E E E"
   end
 end

--- a/test/delux/pattern_test.exs
+++ b/test/delux/pattern_test.exs
@@ -44,17 +44,6 @@ defmodule Delux.PatternTest do
     end
   end
 
-  describe "to_iodata/1" do
-    test "simple conversions" do
-      assert pattern_to_binary(off_pattern()) == "0 3600000 0 0 "
-      assert pattern_to_binary(blink_2hz_pattern()) == "1 250 1 0 0 250 0 0 "
-    end
-
-    test "scaled to LED max brightness" do
-      assert pattern_to_binary(blink_2hz_pattern(), 255) == "255 250 255 0 0 250 0 0 "
-    end
-  end
-
   describe "simplify/1" do
     test "basic effects are already simple" do
       assert Pattern.simplify(off_pattern()) == off_pattern()
@@ -76,10 +65,5 @@ defmodule Delux.PatternTest do
 
       assert simplified == [{1, 0}, {5, 100}]
     end
-  end
-
-  defp pattern_to_binary(pattern, brightness \\ 1) do
-    {iodata, _duration} = Pattern.build_iodata(pattern, brightness)
-    IO.iodata_to_binary(iodata)
   end
 end

--- a/test/delux/pattern_test.exs
+++ b/test/delux/pattern_test.exs
@@ -18,11 +18,11 @@ defmodule Delux.PatternTest do
       assert Pattern.pwm(all_on, 100) == all_on
       assert Pattern.pwm(all_on, 0) == off_pattern()
 
-      assert Pattern.pwm(blip_pattern(), 0) == [{0, 3_600_030}, {0, 0}]
+      assert Pattern.pwm(blip_pattern(), 0) == [{0, 30}, {0, 0}]
     end
 
     test "patterns have same duration when off" do
-      assert Pattern.pwm(blip_pattern(), 0) == [{0, 3_600_030}, {0, 0}]
+      assert Pattern.pwm(blip_pattern(), 0) == [{0, 30}, {0, 0}]
     end
 
     test "pwm needed but off pattern" do
@@ -79,6 +79,7 @@ defmodule Delux.PatternTest do
   end
 
   defp pattern_to_binary(pattern, brightness \\ 1) do
-    pattern |> Pattern.to_iodata(brightness) |> IO.iodata_to_binary()
+    {iodata, _duration} = Pattern.build_iodata(pattern, brightness)
+    IO.iodata_to_binary(iodata)
   end
 end

--- a/test/delux_test.exs
+++ b/test/delux_test.exs
@@ -17,7 +17,7 @@ defmodule DeluxTest do
     pid =
       start_supervised!(
         {Delux,
-         name: nil, glue: [led_path: led_dir, hz: 0], indicators: %{default: %{green: "led0"}}}
+         name: nil, backend: [led_path: led_dir, hz: 0], indicators: %{default: %{green: "led0"}}}
       )
 
     assert info_as_binary(pid, :default) == "off"
@@ -45,7 +45,7 @@ defmodule DeluxTest do
       start_supervised!(
         {Delux,
          name: nil,
-         glue: [led_path: led_dir, hz: 0],
+         backend: [led_path: led_dir, hz: 0],
          indicators: %{default: %{red: "led0", green: "led1", blue: "led2"}}}
       )
 
@@ -78,7 +78,7 @@ defmodule DeluxTest do
     pid =
       start_supervised!(
         {Delux,
-         name: nil, glue: [led_path: led_dir, hz: 0], indicators: %{default: %{green: "led0"}}}
+         name: nil, backend: [led_path: led_dir, hz: 0], indicators: %{default: %{green: "led0"}}}
       )
 
     assert FakeLEDs.read_pattern(0) == "0 3600000 0 0 "
@@ -117,7 +117,7 @@ defmodule DeluxTest do
     pid =
       start_supervised!(
         {Delux,
-         name: nil, glue: [led_path: led_dir, hz: 0], indicators: %{default: %{green: "led0"}}}
+         name: nil, backend: [led_path: led_dir, hz: 0], indicators: %{default: %{green: "led0"}}}
       )
 
     assert FakeLEDs.read_pattern(0) == "0 3600000 0 0 "
@@ -144,7 +144,7 @@ defmodule DeluxTest do
       start_supervised!(
         {Delux,
          name: nil,
-         glue: [led_path: led_dir, hz: 0],
+         backend: [led_path: led_dir, hz: 0],
          indicators: %{
            default: %{red: "led0", green: "led1", blue: "led2"},
            indicator2: %{red: "led3", green: "led4", blue: "led5"}
@@ -213,7 +213,7 @@ defmodule DeluxTest do
     pid =
       start_supervised!(
         {Delux,
-         name: nil, glue: [led_path: led_dir, hz: 0], indicators: %{default: %{green: "led0"}}}
+         name: nil, backend: [led_path: led_dir, hz: 0], indicators: %{default: %{green: "led0"}}}
       )
 
     assert_raise ArgumentError, fn ->
@@ -228,7 +228,7 @@ defmodule DeluxTest do
     pid =
       start_supervised!(
         {Delux,
-         name: nil, glue: [led_path: led_dir, hz: 0], indicators: %{default: %{green: "led0"}}}
+         name: nil, backend: [led_path: led_dir, hz: 0], indicators: %{default: %{green: "led0"}}}
       )
 
     assert_raise ArgumentError, fn ->
@@ -243,7 +243,7 @@ defmodule DeluxTest do
     pid =
       start_supervised!(
         {Delux,
-         name: nil, glue: [led_path: led_dir, hz: 0], indicators: %{default: %{green: "led0"}}}
+         name: nil, backend: [led_path: led_dir, hz: 0], indicators: %{default: %{green: "led0"}}}
       )
 
     assert_raise ArgumentError, fn ->
@@ -265,7 +265,7 @@ defmodule DeluxTest do
 
     pid =
       start_supervised!(
-        {Delux, glue: [led_path: led_dir, hz: 0], indicators: %{default: %{green: "led0"}}}
+        {Delux, backend: [led_path: led_dir, hz: 0], indicators: %{default: %{green: "led0"}}}
       )
 
     assert Process.whereis(Delux) == pid
@@ -298,7 +298,9 @@ defmodule DeluxTest do
     pid =
       start_supervised!(
         {Delux,
-         name: MyDelux, glue: [led_path: led_dir, hz: 0], indicators: %{default: %{green: "led0"}}}
+         name: MyDelux,
+         backend: [led_path: led_dir, hz: 0],
+         indicators: %{default: %{green: "led0"}}}
       )
 
     assert Process.whereis(MyDelux) == pid

--- a/test/delux_test.exs
+++ b/test/delux_test.exs
@@ -92,10 +92,10 @@ defmodule DeluxTest do
     assert info_as_binary(pid) == "green at 1 Hz"
     assert FakeLEDs.read_pattern(0) == "1 500 1 0 0 500 0 0 "
 
-    # Set a lower priority blink and check that nothing changes
+    # Set a lower priority blink and check that nothing gets written
     Delux.render(pid, Delux.Effects.blink(:green, 5), :status)
     assert info_as_binary(pid) == "green at 1 Hz"
-    assert FakeLEDs.read_pattern(0) == "1 500 1 0 0 500 0 0 "
+    assert FakeLEDs.read_pattern(0) == ""
 
     # Clear the higher priority blink
     Delux.render(pid, nil, :notification)
@@ -123,7 +123,7 @@ defmodule DeluxTest do
     # Blip it
     Delux.render(pid, Delux.Effects.blip(:green, :black), :status)
     assert info_as_binary(pid) == "green->black blip"
-    assert FakeLEDs.read_pattern(0) == "0 10 0 0 1 20 1 0 0 3600000 0 0 "
+    assert FakeLEDs.read_pattern(0) == "0 10 0 0 1 20 1 0 0 3600000 0 0"
 
     # Wait for the timeout
     Process.sleep(100)
@@ -163,17 +163,18 @@ defmodule DeluxTest do
     assert FakeLEDs.read_pattern(0) == "1 250 1 0 0 250 0 0 "
     assert FakeLEDs.read_pattern(1) == "0 3600000 0 0 "
     assert FakeLEDs.read_pattern(2) == "1 250 1 0 0 250 0 0 "
-    assert FakeLEDs.read_pattern(3) == "0 3600000 0 0 "
-    assert FakeLEDs.read_pattern(4) == "0 3600000 0 0 "
-    assert FakeLEDs.read_pattern(5) == "0 3600000 0 0 "
+    # Not written
+    assert FakeLEDs.read_pattern(3) == ""
+    assert FakeLEDs.read_pattern(4) == ""
+    assert FakeLEDs.read_pattern(5) == ""
 
     # Start a second blink on indicator2
     Delux.render(pid, %{indicator2: Delux.Effects.blink(:blue, 1)}, :status)
     assert info_as_binary(pid) == "magenta at 2 Hz"
     assert info_as_binary(pid, :indicator2) == "blue at 1 Hz"
-    assert FakeLEDs.read_pattern(0) == "1 250 1 0 0 250 0 0 "
-    assert FakeLEDs.read_pattern(1) == "0 3600000 0 0 "
-    assert FakeLEDs.read_pattern(2) == "1 250 1 0 0 250 0 0 "
+    assert FakeLEDs.read_pattern(0) == ""
+    assert FakeLEDs.read_pattern(1) == ""
+    assert FakeLEDs.read_pattern(2) == ""
     assert FakeLEDs.read_pattern(3) == "0 3600000 0 0 "
     assert FakeLEDs.read_pattern(4) == "0 3600000 0 0 "
     assert FakeLEDs.read_pattern(5) == "1 500 1 0 0 500 0 0 "
@@ -185,18 +186,21 @@ defmodule DeluxTest do
     assert FakeLEDs.read_pattern(0) == "0 3600000 0 0 "
     assert FakeLEDs.read_pattern(1) == "0 3600000 0 0 "
     assert FakeLEDs.read_pattern(2) == "0 3600000 0 0 "
-    assert FakeLEDs.read_pattern(3) == "0 3600000 0 0 "
-    assert FakeLEDs.read_pattern(4) == "0 3600000 0 0 "
-    assert FakeLEDs.read_pattern(5) == "1 500 1 0 0 500 0 0 "
+    assert FakeLEDs.read_pattern(3) == ""
+    assert FakeLEDs.read_pattern(4) == ""
+    assert FakeLEDs.read_pattern(5) == ""
 
     # Turn off the second blink
     Delux.render(pid, %{indicator2: nil}, :status)
     assert info_as_binary(pid) == "off"
     assert info_as_binary(pid, :indicator2) == "off"
 
-    for i <- 0..5 do
-      assert FakeLEDs.read_pattern(i) == "0 3600000 0 0 "
-    end
+    assert FakeLEDs.read_pattern(0) == ""
+    assert FakeLEDs.read_pattern(1) == ""
+    assert FakeLEDs.read_pattern(2) == ""
+    assert FakeLEDs.read_pattern(3) == "0 3600000 0 0 "
+    assert FakeLEDs.read_pattern(4) == "0 3600000 0 0 "
+    assert FakeLEDs.read_pattern(5) == "0 3600000 0 0 "
   end
 
   @tag :tmp_dir

--- a/test/delux_test.exs
+++ b/test/delux_test.exs
@@ -16,7 +16,8 @@ defmodule DeluxTest do
 
     pid =
       start_supervised!(
-        {Delux, name: nil, glue: [led_path: led_dir], indicators: %{default: %{green: "led0"}}}
+        {Delux,
+         name: nil, glue: [led_path: led_dir, hz: 0], indicators: %{default: %{green: "led0"}}}
       )
 
     assert info_as_binary(pid, :default) == "off"
@@ -44,7 +45,7 @@ defmodule DeluxTest do
       start_supervised!(
         {Delux,
          name: nil,
-         glue: [led_path: led_dir],
+         glue: [led_path: led_dir, hz: 0],
          indicators: %{default: %{red: "led0", green: "led1", blue: "led2"}}}
       )
 
@@ -76,7 +77,8 @@ defmodule DeluxTest do
 
     pid =
       start_supervised!(
-        {Delux, name: nil, glue: [led_path: led_dir], indicators: %{default: %{green: "led0"}}}
+        {Delux,
+         name: nil, glue: [led_path: led_dir, hz: 0], indicators: %{default: %{green: "led0"}}}
       )
 
     assert FakeLEDs.read_pattern(0) == "0 3600000 0 0 "
@@ -114,7 +116,8 @@ defmodule DeluxTest do
 
     pid =
       start_supervised!(
-        {Delux, name: nil, glue: [led_path: led_dir], indicators: %{default: %{green: "led0"}}}
+        {Delux,
+         name: nil, glue: [led_path: led_dir, hz: 0], indicators: %{default: %{green: "led0"}}}
       )
 
     assert FakeLEDs.read_pattern(0) == "0 3600000 0 0 "
@@ -141,7 +144,7 @@ defmodule DeluxTest do
       start_supervised!(
         {Delux,
          name: nil,
-         glue: [led_path: led_dir],
+         glue: [led_path: led_dir, hz: 0],
          indicators: %{
            default: %{red: "led0", green: "led1", blue: "led2"},
            indicator2: %{red: "led3", green: "led4", blue: "led5"}
@@ -209,7 +212,8 @@ defmodule DeluxTest do
 
     pid =
       start_supervised!(
-        {Delux, name: nil, glue: [led_path: led_dir], indicators: %{default: %{green: "led0"}}}
+        {Delux,
+         name: nil, glue: [led_path: led_dir, hz: 0], indicators: %{default: %{green: "led0"}}}
       )
 
     assert_raise ArgumentError, fn ->
@@ -223,7 +227,8 @@ defmodule DeluxTest do
 
     pid =
       start_supervised!(
-        {Delux, name: nil, glue: [led_path: led_dir], indicators: %{default: %{green: "led0"}}}
+        {Delux,
+         name: nil, glue: [led_path: led_dir, hz: 0], indicators: %{default: %{green: "led0"}}}
       )
 
     assert_raise ArgumentError, fn ->
@@ -237,7 +242,8 @@ defmodule DeluxTest do
 
     pid =
       start_supervised!(
-        {Delux, name: nil, glue: [led_path: led_dir], indicators: %{default: %{green: "led0"}}}
+        {Delux,
+         name: nil, glue: [led_path: led_dir, hz: 0], indicators: %{default: %{green: "led0"}}}
       )
 
     assert_raise ArgumentError, fn ->
@@ -259,7 +265,7 @@ defmodule DeluxTest do
 
     pid =
       start_supervised!(
-        {Delux, glue: [led_path: led_dir], indicators: %{default: %{green: "led0"}}}
+        {Delux, glue: [led_path: led_dir, hz: 0], indicators: %{default: %{green: "led0"}}}
       )
 
     assert Process.whereis(Delux) == pid
@@ -292,7 +298,7 @@ defmodule DeluxTest do
     pid =
       start_supervised!(
         {Delux,
-         name: MyDelux, glue: [led_path: led_dir], indicators: %{default: %{green: "led0"}}}
+         name: MyDelux, glue: [led_path: led_dir, hz: 0], indicators: %{default: %{green: "led0"}}}
       )
 
     assert Process.whereis(MyDelux) == pid

--- a/test/delux_test.exs
+++ b/test/delux_test.exs
@@ -16,7 +16,7 @@ defmodule DeluxTest do
 
     pid =
       start_supervised!(
-        {Delux, name: nil, led_path: led_dir, indicators: %{default: %{green: "led0"}}}
+        {Delux, name: nil, glue: [led_path: led_dir], indicators: %{default: %{green: "led0"}}}
       )
 
     assert info_as_binary(pid, :default) == "off"
@@ -44,7 +44,7 @@ defmodule DeluxTest do
       start_supervised!(
         {Delux,
          name: nil,
-         led_path: led_dir,
+         glue: [led_path: led_dir],
          indicators: %{default: %{red: "led0", green: "led1", blue: "led2"}}}
       )
 
@@ -76,7 +76,7 @@ defmodule DeluxTest do
 
     pid =
       start_supervised!(
-        {Delux, name: nil, led_path: led_dir, indicators: %{default: %{green: "led0"}}}
+        {Delux, name: nil, glue: [led_path: led_dir], indicators: %{default: %{green: "led0"}}}
       )
 
     assert FakeLEDs.read_pattern(0) == "0 3600000 0 0 "
@@ -114,7 +114,7 @@ defmodule DeluxTest do
 
     pid =
       start_supervised!(
-        {Delux, name: nil, led_path: led_dir, indicators: %{default: %{green: "led0"}}}
+        {Delux, name: nil, glue: [led_path: led_dir], indicators: %{default: %{green: "led0"}}}
       )
 
     assert FakeLEDs.read_pattern(0) == "0 3600000 0 0 "
@@ -141,7 +141,7 @@ defmodule DeluxTest do
       start_supervised!(
         {Delux,
          name: nil,
-         led_path: led_dir,
+         glue: [led_path: led_dir],
          indicators: %{
            default: %{red: "led0", green: "led1", blue: "led2"},
            indicator2: %{red: "led3", green: "led4", blue: "led5"}
@@ -209,7 +209,7 @@ defmodule DeluxTest do
 
     pid =
       start_supervised!(
-        {Delux, name: nil, led_path: led_dir, indicators: %{default: %{green: "led0"}}}
+        {Delux, name: nil, glue: [led_path: led_dir], indicators: %{default: %{green: "led0"}}}
       )
 
     assert_raise ArgumentError, fn ->
@@ -223,7 +223,7 @@ defmodule DeluxTest do
 
     pid =
       start_supervised!(
-        {Delux, name: nil, led_path: led_dir, indicators: %{default: %{green: "led0"}}}
+        {Delux, name: nil, glue: [led_path: led_dir], indicators: %{default: %{green: "led0"}}}
       )
 
     assert_raise ArgumentError, fn ->
@@ -237,7 +237,7 @@ defmodule DeluxTest do
 
     pid =
       start_supervised!(
-        {Delux, name: nil, led_path: led_dir, indicators: %{default: %{green: "led0"}}}
+        {Delux, name: nil, glue: [led_path: led_dir], indicators: %{default: %{green: "led0"}}}
       )
 
     assert_raise ArgumentError, fn ->
@@ -257,7 +257,11 @@ defmodule DeluxTest do
 
     FakeLEDs.create_leds(led_dir, 1)
 
-    pid = start_supervised!({Delux, led_path: led_dir, indicators: %{default: %{green: "led0"}}})
+    pid =
+      start_supervised!(
+        {Delux, glue: [led_path: led_dir], indicators: %{default: %{green: "led0"}}}
+      )
+
     assert Process.whereis(Delux) == pid
 
     assert singleton_info_as_binary() == "off"
@@ -287,7 +291,8 @@ defmodule DeluxTest do
 
     pid =
       start_supervised!(
-        {Delux, name: MyDelux, led_path: led_dir, indicators: %{default: %{green: "led0"}}}
+        {Delux,
+         name: MyDelux, glue: [led_path: led_dir], indicators: %{default: %{green: "led0"}}}
       )
 
     assert Process.whereis(MyDelux) == pid

--- a/test/support/fake_leds.ex
+++ b/test/support/fake_leds.ex
@@ -37,7 +37,7 @@ defmodule Delux.Support.FakeLEDs do
   @spec read_pattern(non_neg_integer()) :: binary()
   def read_pattern(index) do
     # This is a little tricky since tests must read the pattern
-    # after every time it's set. This is due to how the glue code
+    # after every time it's set. This is due to how the backend code
     # to Linux just keeps appending to the magic file to set patterns,
     # but our simulation doesn't truncate the file after every write.
     handle = Process.get({__MODULE__, index})


### PR DESCRIPTION
This includes several commits that made it possible to adjust timing. See the last commit for the most interesting details. The previous commits lay 
the ground work needed by that last one.

