### PR TITLE
Support starting Delux as an OTP application

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,14 @@ Once you feel good about the indicators and slots, it's time to configure
 
 ## Configuration
 
-After adding `delux` to your mix dependencies, add `Delux` to a supervision
-tree of your choice. The childspec looks like:
+After adding `delux` to your mix dependencies, you can either add `Delux` to a
+supervision tree of your choice or add a `:delux` configuration to your
+application environment (`config.exs`). The tradeoff is that having `Delux`
+start itself by specifying an application config can be really convenient, but
+adding `Delux` to your supervision tree allows runtime configuration and more
+control over failure recovery.
+
+Starting with the supervision tree approach, here's an example childspec:
 
 ```elixir
   {Delux,
@@ -126,22 +132,30 @@ tree of your choice. The childspec looks like:
    }}
 ```
 
-The above configuration shows two indicators. The first is called `:default`
-and is an RGB indicator. The second is a lone red LED that's used as
-`:indicator2`.  As mentioned before, if you only have one indicator, call it
-`:default`.
+The above configuration shows two indicators. The first is called `:default` and
+is an RGB indicator. The second is a lone red LED that's used as `:indicator2`.
+As mentioned before, if you only have one indicator, call it `:default`.
 
-Other options include setting the list of slots and giving the `Delux`
-GenServer a name. If you don't give the `Delux` GenServer a name, it will
-register itself as a singleton and you won't have to pass the server name or
-pid to any of the API calls.
+Other options include setting the list of slots and giving the `Delux` GenServer
+a name. If you don't give the `Delux` GenServer a name, it will register itself
+as a singleton and you won't have to pass the server name or pid to any of the
+API calls.
+
+If you'd like Delux to start itself automatically, add the configuration to your
+`config.exs` or a file that it includes. Here's an example:
+
+```elixir
+config :delux,
+   indicators: %{
+     default: %{red: "led0:red", green: "led0:green", blue: "led0:blue"},
+     indicator2: %{red: "led1"}
+   }}
+```
 
 ## Use
 
-For sake of example, lets start the `Delux` GenServer the manual way by calling
-`start_link/1` directly. The usual way in your programs would be to add the
-childspec to the supervision tree as shown earlier. Modify the LED names to
-whatever you have.
+For sake of example, let's start the `Delux` GenServer the manual way by calling
+`start_link/1` directly. Modify the LED names to whatever you have.
 
 ```elixir
 iex> Delux.start_link(indicators: %{
@@ -150,8 +164,8 @@ iex> Delux.start_link(indicators: %{
    })
 ```
 
-After you have a `Delux` GenServer and running, call `Delux.render/1` to turn
-on the default indicator in the default slot:
+After you have a `Delux` GenServer and running, call `Delux.render/1` to turn on
+the default indicator in the default slot:
 
 ```elixir
 iex> Delux.render(Delux.Effects.on(:white))

--- a/lib/delux/application.ex
+++ b/lib/delux/application.ex
@@ -1,0 +1,20 @@
+defmodule Delux.Application do
+  @moduledoc false
+
+  use Application
+
+  @impl Application
+  def start(_type, _args) do
+    # Optionally start Delux if configured in the application
+    # environment
+
+    children =
+      case Application.get_all_env(:delux) do
+        [] -> []
+        config -> [{Delux, config}]
+      end
+
+    opts = [strategy: :one_for_one, name: Delux.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,8 @@ defmodule Delux.MixProject do
 
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger],
+      mod: {Delux.Application, []}
     ]
   end
 

--- a/test/delux_app_test.exs
+++ b/test/delux_app_test.exs
@@ -1,0 +1,46 @@
+defmodule DeluxAppTest do
+  use ExUnit.Case, async: false
+
+  alias Delux.Support.FakeLEDs
+
+  test "empty config doesn't start Delux" do
+    assert Process.whereis(Delux) == nil
+  end
+
+  @tag :tmp_dir
+  test "single LED configuration", %{tmp_dir: led_dir} do
+    FakeLEDs.create_leds(led_dir, 1)
+
+    :ok = Application.stop(:delux)
+    Application.put_env(:delux, :backend, led_path: led_dir, hz: 0)
+    Application.put_env(:delux, :indicators, %{default: %{green: "led0"}})
+    :ok = Application.start(:delux)
+
+    on_exit(fn ->
+      Application.stop(:delux)
+      :application.unset_env(:delux, :backend)
+      :application.unset_env(:delux, :indicators)
+      :ok = Application.start(:delux)
+    end)
+
+    assert info_as_binary(:default) == "off"
+
+    # Check initialized to off
+    assert FakeLEDs.read_trigger(0) == "pattern"
+    assert FakeLEDs.read_pattern(0) == "0 3600000 0 0 "
+
+    # Blink it
+    Delux.render(Delux.Effects.blink(:green, 2), :status)
+    assert info_as_binary() == "green at 2 Hz"
+    assert FakeLEDs.read_pattern(0) == "1 250 1 0 0 250 0 0 "
+
+    # Clear it
+    Delux.clear()
+    assert info_as_binary() == "off"
+    assert FakeLEDs.read_pattern(0) == "0 3600000 0 0 "
+  end
+
+  defp info_as_binary(indicator \\ :default) do
+    Delux.info_as_ansidata(indicator) |> IO.ANSI.format(false) |> IO.chardata_to_string()
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,3 @@
+Logger.configure(level: :warning)
+
 ExUnit.start()


### PR DESCRIPTION
This can be very convenient and allow Delux to start earlier in the boot
process. The readme has been updated to talk about the main tradeoffs
and hopefully nudge people to adding it to their supervision trees. This
isn't always easy to do, though.
