### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # 💡 delux 💡
 
 [![Hex version](https://img.shields.io/hexpm/v/delux.svg "Hex version")](https://hex.pm/packages/delux)
-[![API docs](https://img.shields.io/hexpm/v/delux.svg?label=hexdocs "API docs")](https://hexdocs.pm/delux/Delux.html)
+[![API docs](https://img.shields.io/hexpm/v/delux.svg?label=hexdocs "API docs")](https://delux.hexdocs.pm/Delux.html)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/elixir-circuits/delux/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/elixir-circuits/delux/tree/main)
 [![REUSE status](https://api.reuse.software/badge/github.com/elixir-circuits/delux)](https://api.reuse.software/info/github.com/elixir-circuits/delux)
 


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://delux.hexdocs.pm/Delux.html): Status 404
⚠️ Verification finished: 0 success, 1 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>